### PR TITLE
Fix icon CSS glitch

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -57,7 +57,7 @@ register_css <<CSS
 }
 
 .btn-social.steam:before {
-    content:"\f1b6";
+    content: $fa-var-steam;
 }
 
 CSS


### PR DESCRIPTION
Somehow using direct unicode here resulted in this: https://meta.discourse.org/t/youtube-embeds-appear-very-small/31419
Using the variable fixes this issue however